### PR TITLE
Shohei's refactoring

### DIFF
--- a/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
+++ b/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
@@ -49,6 +49,8 @@ namespace OpenControllersInterface {
   };
 
 
+  class OpenControllerException {
+  };
   
   class OpenController {
   public:
@@ -60,19 +62,19 @@ namespace OpenControllersInterface {
     static bool initRT();
     
     void setAllowUnprogrammedP(bool val) {
-      allow_unprogrammed_p = val;
+      allow_unprogrammed_p_ = val;
     }
     
     void setStatsPublishP(bool val) {
-      stats_publish_p = val;
+      stats_publish_p_ = val;
     }
     
     void setRobotXMLFile(std::string val) {
-      robot_xml_file = val;
+      robot_xml_file_ = val;
     }
 
     bool setDryRun(bool _dryrun) {
-      dryrunp = _dryrun;
+      dryrunp_ = _dryrun;
       return _dryrun;
     }
 
@@ -115,31 +117,30 @@ namespace OpenControllersInterface {
     void timespecInc(struct timespec &tick, int nsec);
     double publishJitter(double start);
 
-    std::string piddir;
-    std::string pidfile;
-    bool dryrunp;
-    bool not_sleep_clock;
-    bool allow_unprogrammed_p;
-    bool stats_publish_p;
-    bool initialized_p;
-    bool g_reset_motors;
-    bool g_quit;
-    bool g_halt_requested;
-    bool g_halt_motors;
-    bool g_publish_trace_requested;
-    std::string robot_xml_file;
-    double min_acceptable_rt_loop_frequency;
-    double period;
-    std::string g_robot_desc;
-    pr2_hardware_interface::HardwareInterface* hw;
-    boost::shared_ptr<pr2_controller_manager::ControllerManager> cm;
-    realtime_tools::RealtimePublisher<std_msgs::Float64> *rtpublisher;
-    realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray> *publisher;
-    Stat g_stats;
+    std::string piddir_;
+    std::string pidfile_;
+    bool dryrunp_;
+    bool not_sleep_clock_;
+    bool allow_unprogrammed_p_;
+    bool stats_publish_p_;
+    bool g_reset_motors_;
+    bool g_quit_;;
+    bool g_halt_requested_;
+    bool g_halt_motors_;
+    bool g_publish_trace_requested_;
+    std::string robot_xml_file_;
+    double min_acceptable_rt_loop_frequency_;
+    double period_;
+    std::string g_robot_desc_;
+    pr2_hardware_interface::HardwareInterface* hw_;
+    boost::shared_ptr<pr2_controller_manager::ControllerManager> cm_;
+    realtime_tools::RealtimePublisher<std_msgs::Float64> *rtpublisher_;
+    realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray> *publisher_;
+    Stat g_stats_;
 
-    ros::ServiceServer reset_service;
-    ros::ServiceServer halt_service;
-    ros::ServiceServer publishTrace_service;
+    ros::ServiceServer reset_service_;
+    ros::ServiceServer halt_service_;
+    ros::ServiceServer publishTrace_service_;
     
   private:
   };

--- a/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
+++ b/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
@@ -48,10 +48,6 @@ namespace OpenControllersInterface {
     double rt_loop_frequency;
   };
 
-
-  class OpenControllerException {
-  };
-  
   class OpenController {
   public:
     OpenController();
@@ -134,8 +130,8 @@ namespace OpenControllersInterface {
     std::string g_robot_desc_;
     pr2_hardware_interface::HardwareInterface* hw_;
     boost::shared_ptr<pr2_controller_manager::ControllerManager> cm_;
-    realtime_tools::RealtimePublisher<std_msgs::Float64> *rtpublisher_;
-    realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray> *publisher_;
+    boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::Float64> > rtpublisher_;
+    boost::shared_ptr<realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray> > publisher_;
     Stat g_stats_;
 
     ros::ServiceServer reset_service_;

--- a/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
+++ b/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
@@ -94,6 +94,7 @@ namespace OpenControllersInterface {
     
     // virtual function you need to impelement
     void initialize();
+    void loadRobotDescription();
     void startMain();
     void finalize();
 
@@ -106,6 +107,7 @@ namespace OpenControllersInterface {
   protected:
     int lock_fd(int fd);
     virtual void initializeROS(ros::NodeHandle& node) = 0;
+    virtual void initializeCM() = 0;
     virtual void initializeHW() = 0;
     
     void publishDiagnostics();

--- a/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
+++ b/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
@@ -48,11 +48,21 @@ namespace OpenControllersInterface {
     double rt_loop_frequency;
   };
 
+
+  class ControllerStatus {
+    public:
+    ControllerStatus(){}
+    virtual ~ControllerStatus(){}
+    virtual bool isHealthy(){return true;}
+  };
+  typedef boost::shared_ptr<ControllerStatus> ControllerStatusPtr;
+
   class OpenController {
   public:
     OpenController();
     virtual ~OpenController();
-    virtual bool updateJoints(struct timespec*) = 0;
+    virtual ControllerStatusPtr updateJoints(struct timespec*) = 0;
+    virtual ControllerStatusPtr recoverController() = 0;
     virtual void finalizeHW() = 0;
 
     static bool initRT();

--- a/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
+++ b/open_controllers_interface/include/open_controllers_interface/open_controllers_interface.h
@@ -122,7 +122,6 @@ namespace OpenControllersInterface {
     bool g_reset_motors_;
     bool g_quit_;;
     bool g_halt_requested_;
-    bool g_halt_motors_;
     bool g_publish_trace_requested_;
     std::string robot_xml_file_;
     double min_acceptable_rt_loop_frequency_;

--- a/open_controllers_interface/src/open_controllers_interface.cpp
+++ b/open_controllers_interface/src/open_controllers_interface.cpp
@@ -89,7 +89,7 @@ namespace OpenControllersInterface {
   }
 
   void OpenController::publishDiagnostics() {
-    if (publisher_ && publisher_->trylock())
+    if (!!publisher_ && publisher_->trylock())
     {
       accumulator_set<double, stats<tag::max, tag::mean> > zero;
       vector<diagnostic_msgs::DiagnosticStatus> statuses;
@@ -216,7 +216,7 @@ namespace OpenControllersInterface {
                               &OpenController::publishTraceService,
                               this);
     
-    publisher_ = new realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray>(node, "/diagnostics", 2);
+    publisher_.reset(new realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray>(node, "/diagnostics", 2));
 
     if (!node.getParam("not_sleep_clock", not_sleep_clock_)) {
       not_sleep_clock_ = false;
@@ -250,7 +250,7 @@ namespace OpenControllersInterface {
     ROS_INFO("piddir is: %s", piddir_.c_str());
     
     if (stats_publish_p_) {
-      rtpublisher_ = new realtime_tools::RealtimePublisher<std_msgs::Float64>(node, "realtime", 2);
+      rtpublisher_.reset(new realtime_tools::RealtimePublisher<std_msgs::Float64>(node, "realtime", 2));
     }
     
     // initialize pid file
@@ -349,7 +349,7 @@ namespace OpenControllersInterface {
     double jitter = now() - start;
     g_stats_.jitter_acc(jitter);
     // Publish realtime loops statistics, if requested
-    if (rtpublisher_)
+    if (!!rtpublisher_)
       {
         if (rtpublisher_->trylock())
           {
@@ -554,11 +554,11 @@ namespace OpenControllersInterface {
     ec.update(false, true);
 #endif
     //pthread_join(diagnosticThread, 0);
-    if (publisher_) {
+    if (!!publisher_) {
       publisher_->stop();
-      publisher_ = NULL;
+      publisher_.reset();
     }
-    delete rtpublisher_;
+    rtpublisher_.reset();
     //ros::shutdown();
     //return (void *)rv;
     fprintf(stderr, "exiting from finalize\n");

--- a/open_controllers_interface/src/open_controllers_interface.cpp
+++ b/open_controllers_interface/src/open_controllers_interface.cpp
@@ -493,10 +493,10 @@ namespace OpenControllersInterface {
         (tick.tv_sec + double(tick.tv_nsec)/NSEC_PER_SECOND);
       if (overrun_time > 0.0)
       {
-        ROS_WARN("overrun: %f", overrun_time);
+        ROS_WARN("  overrun: %f", overrun_time);
         double jitter = publishJitter(start);
-        ROS_WARN("jitter: %f", jitter);
-        ROS_WARN("loop:   %d", g_stats_.loop_count);
+        ROS_WARN("  jitter: %f", jitter);
+        ROS_WARN("  loop:   %d", g_stats_.loop_count);
         // Total amount of time the loop took to run
         g_stats_.overrun_loop_sec = overrun_time;
 
@@ -538,7 +538,7 @@ namespace OpenControllersInterface {
                            + double(sleep_after.tv_nsec-sleep_before.tv_nsec)/NSEC_PER_SECOND);
       //double jitter = (after.tv_sec - tick.tv_sec + double(after.tv_nsec-tick.tv_nsec)/NSEC_PER_SECOND);
       if (overrun_time > 0.0) {
-        ROS_WARN("sleep_time: %f", sleep_time);
+        ROS_WARN("  sleep_time: %f", sleep_time);
       }
 
       // Halt the motors, if requested by a service call

--- a/open_controllers_interface/src/open_controllers_interface.cpp
+++ b/open_controllers_interface/src/open_controllers_interface.cpp
@@ -56,7 +56,7 @@ static const int USEC_PER_SECOND = 1e6;
 
 namespace OpenControllersInterface {
   OpenController::OpenController():
-    not_sleep_clock(false), initialized_p(false) { // constructor
+    not_sleep_clock_(false) { // constructor
   }
 
   OpenController::~OpenController() {
@@ -64,7 +64,7 @@ namespace OpenControllersInterface {
   }
   bool OpenController::resetMotorsService(std_srvs::Empty::Request &req,
                                           std_srvs::Empty::Response &resp) {
-    g_reset_motors = true;
+    g_reset_motors_ = true;
     return true;
   }
 
@@ -76,7 +76,7 @@ namespace OpenControllersInterface {
   
   bool OpenController::publishTraceService(std_srvs::Empty::Request &req,
                                            std_srvs::Empty::Response &resp) {
-    g_publish_trace_requested = true;
+    g_publish_trace_requested_ = true;
     return true;
   }
 
@@ -89,7 +89,7 @@ namespace OpenControllersInterface {
   }
 
   void OpenController::publishDiagnostics() {
-    if (publisher && publisher->trylock())
+    if (publisher_ && publisher_->trylock())
     {
       accumulator_set<double, stats<tag::max, tag::mean> > zero;
       vector<diagnostic_msgs::DiagnosticStatus> statuses;
@@ -98,26 +98,26 @@ namespace OpenControllersInterface {
       static double max_ec = 0, max_cm = 0, max_loop = 0, max_jitter = 0;
       double avg_ec, avg_cm, avg_loop, avg_jitter;
 
-      avg_ec           = extract_result<tag::mean>(g_stats.ec_acc);
-      avg_cm           = extract_result<tag::mean>(g_stats.cm_acc);
-      avg_loop         = extract_result<tag::mean>(g_stats.loop_acc);
-      max_ec           = std::max(max_ec, extract_result<tag::max>(g_stats.ec_acc));
-      max_cm           = std::max(max_cm, extract_result<tag::max>(g_stats.cm_acc));
-      max_loop         = std::max(max_loop, extract_result<tag::max>(g_stats.loop_acc));
-      g_stats.ec_acc   = zero;
-      g_stats.cm_acc   = zero;
-      g_stats.loop_acc = zero;
+      avg_ec           = extract_result<tag::mean>(g_stats_.ec_acc);
+      avg_cm           = extract_result<tag::mean>(g_stats_.cm_acc);
+      avg_loop         = extract_result<tag::mean>(g_stats_.loop_acc);
+      max_ec           = std::max(max_ec, extract_result<tag::max>(g_stats_.ec_acc));
+      max_cm           = std::max(max_cm, extract_result<tag::max>(g_stats_.cm_acc));
+      max_loop         = std::max(max_loop, extract_result<tag::max>(g_stats_.loop_acc));
+      g_stats_.ec_acc   = zero;
+      g_stats_.cm_acc   = zero;
+      g_stats_.loop_acc = zero;
 
       // Publish average loop jitter
-      avg_jitter         = extract_result<tag::mean>(g_stats.jitter_acc);
-      max_jitter         = std::max(max_jitter, extract_result<tag::max>(g_stats.jitter_acc));
-      g_stats.jitter_acc = zero;
+      avg_jitter         = extract_result<tag::mean>(g_stats_.jitter_acc);
+      max_jitter         = std::max(max_jitter, extract_result<tag::max>(g_stats_.jitter_acc));
+      g_stats_.jitter_acc = zero;
 
       static bool first = true;
       if (first)
       {
         first = false;
-        status.add("Robot Description", g_robot_desc);
+        status.add("Robot Description", g_robot_desc_);
       }
 
       status.addf("Max EtherCAT roundtrip (us)", "%.2f", max_ec*USEC_PER_SECOND);
@@ -128,18 +128,18 @@ namespace OpenControllersInterface {
       status.addf("Avg Total Loop roundtrip (us)", "%.2f", avg_loop*USEC_PER_SECOND);
       status.addf("Max Loop Jitter (us)", "%.2f", max_jitter * USEC_PER_SECOND);
       status.addf("Avg Loop Jitter (us)", "%.2f", avg_jitter * USEC_PER_SECOND);
-      status.addf("Control Loop Overruns", "%d", g_stats.overruns);
-      status.addf("Total Loop Count", "%ul", g_stats.loop_count);
-      status.addf("Recent Control Loop Overruns", "%d", g_stats.recent_overruns);
+      status.addf("Control Loop Overruns", "%d", g_stats_.overruns);
+      status.addf("Total Loop Count", "%ul", g_stats_.loop_count);
+      status.addf("Recent Control Loop Overruns", "%d", g_stats_.recent_overruns);
       status.addf("Last Control Loop Overrun Cause", "ec: %.2fus, cm: %.2fus", 
-                  g_stats.overrun_ec*USEC_PER_SECOND, g_stats.overrun_cm*USEC_PER_SECOND);
-      status.addf("Last Overrun Loop Time (us)", "%.2f", g_stats.overrun_loop_sec * USEC_PER_SECOND);
-      status.addf("Realtime Loop Frequency", "%.4f", g_stats.rt_loop_frequency);
+                  g_stats_.overrun_ec*USEC_PER_SECOND, g_stats_.overrun_cm*USEC_PER_SECOND);
+      status.addf("Last Overrun Loop Time (us)", "%.2f", g_stats_.overrun_loop_sec * USEC_PER_SECOND);
+      status.addf("Realtime Loop Frequency", "%.4f", g_stats_.rt_loop_frequency);
 
       status.name = "Realtime Control Loop";
-      if (g_stats.overruns > 0 && g_stats.last_overrun < 30)
+      if (g_stats_.overruns > 0 && g_stats_.last_overrun < 30)
       {
-        if (g_stats.last_severe_overrun < 30)
+        if (g_stats_.last_severe_overrun < 30)
           status.level = 1;
         else
           status.level = 0;
@@ -150,19 +150,19 @@ namespace OpenControllersInterface {
         status.level = 0;
         status.message = "OK";
       }
-      g_stats.recent_overruns = 0;
-      g_stats.last_overrun++;
-      g_stats.last_severe_overrun++;
+      g_stats_.recent_overruns = 0;
+      g_stats_.last_overrun++;
+      g_stats_.last_severe_overrun++;
 
-      if (g_stats.rt_loop_not_making_timing)
+      if (g_stats_.rt_loop_not_making_timing)
       {
-        status.mergeSummaryf(status.ERROR, "Halting, realtime loop only ran at %.4f Hz", g_stats.halt_rt_loop_frequency);
+        status.mergeSummaryf(status.ERROR, "Halting, realtime loop only ran at %.4f Hz", g_stats_.halt_rt_loop_frequency);
       }
 
       statuses.push_back(status);
-      publisher->msg_.status = statuses;
-      publisher->msg_.header.stamp = ros::Time::now();
-      publisher->unlockAndPublish();
+      publisher_->msg_.status = statuses;
+      publisher_->msg_.header.stamp = ros::Time::now();
+      publisher_->unlockAndPublish();
     }
   }
 
@@ -203,59 +203,59 @@ namespace OpenControllersInterface {
   void OpenController::initialize() {
     ros::NodeHandle node("~");
     initializeROS(node);            // initialize ros anyway
-    reset_service
+    reset_service_
       = node.advertiseService("reset_motors",
                               &OpenController::resetMotorsService,
                               this);
-    halt_service
+    halt_service_
       = node.advertiseService("halt_motors",
                               &OpenController::haltMotorsService,
                               this);
-    publishTrace_service
+    publishTrace_service_
       = node.advertiseService("publish_trace",
                               &OpenController::publishTraceService,
                               this);
     
-    publisher = new realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray>(node, "/diagnostics", 2);
+    publisher_ = new realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray>(node, "/diagnostics", 2);
 
-    if (!node.getParam("not_sleep_clock", not_sleep_clock)) {
-      not_sleep_clock = false;
+    if (!node.getParam("not_sleep_clock", not_sleep_clock_)) {
+      not_sleep_clock_ = false;
     }
 
-    if (!node.getParam("min_acceptable_rt_loop_frequency", min_acceptable_rt_loop_frequency))
+    if (!node.getParam("min_acceptable_rt_loop_frequency", min_acceptable_rt_loop_frequency_))
     {
-      min_acceptable_rt_loop_frequency = 750.0; 
+      min_acceptable_rt_loop_frequency_ = 750.0; 
     }
     else 
     {
-      ROS_WARN("min_acceptable_rt_loop_frequency changed to %f", min_acceptable_rt_loop_frequency);
+      ROS_WARN("min_acceptable_rt_loop_frequency changed to %f", min_acceptable_rt_loop_frequency_);
     }
     
     // read period
-    if (!node.getParam("rt_period", period))
+    if (!node.getParam("rt_period", period_))
     {
       ROS_WARN("failed to read rt_period parameter");
-      period = 1e+6;            // 1ms in nanoseconds
+      period_ = 1e+6;            // 1ms in nanoseconds
     }
-    ROS_INFO("realtime loop period is %f", period);
+    ROS_INFO("realtime loop period is %f", period_);
 
-    if (!node.getParam("pidfile", pidfile)) {
-      pidfile = "open_controller.pid";
+    if (!node.getParam("pidfile", pidfile_)) {
+      pidfile_ = "open_controller.pid";
     }
-    ROS_INFO("pidfile is: %s", pidfile.c_str());
+    ROS_INFO("pidfile is: %s", pidfile_.c_str());
 
-    if (!node.getParam("piddir", piddir)) {
-      piddir = "/var/tmp/run/";
+    if (!node.getParam("piddir", piddir_)) {
+      piddir_ = "/var/tmp/run/";
     }
-    ROS_INFO("piddir is: %s", piddir.c_str());
+    ROS_INFO("piddir is: %s", piddir_.c_str());
     
-    if (stats_publish_p) {
-      rtpublisher = new realtime_tools::RealtimePublisher<std_msgs::Float64>(node, "realtime", 2);
+    if (stats_publish_p_) {
+      rtpublisher_ = new realtime_tools::RealtimePublisher<std_msgs::Float64>(node, "realtime", 2);
     }
     
     // initialize pid file
     if (setupPidFile() < 0) {
-      ROS_FATAL("pid file (%s/%s) already exists", piddir.c_str(), pidfile.c_str());
+      ROS_FATAL("pid file (%s/%s) already exists", piddir_.c_str(), pidfile_.c_str());
       exit(1);
     }
     
@@ -266,8 +266,8 @@ namespace OpenControllersInterface {
     loadRobotDescription();
     initializeHW();
     
-    for (size_t i = 0; i < cm->state_->joint_states_.size(); i++) {
-      cm->state_->joint_states_[i].calibrated_ = true;
+    for (size_t i = 0; i < cm_->state_->joint_states_.size(); i++) {
+      cm_->state_->joint_states_[i].calibrated_ = true;
     }
 
    // Publish one-time before entering real-time to pre-allocate message vectors
@@ -294,19 +294,19 @@ namespace OpenControllersInterface {
     
     TiXmlDocument xml;
     struct stat st;
-    if (0 == stat(robot_xml_file.c_str(), &st))
+    if (0 == stat(robot_xml_file_.c_str(), &st))
     {
-      xml.LoadFile(robot_xml_file.c_str());
+      xml.LoadFile(robot_xml_file_.c_str());
     }
     else
     {
       ROS_INFO("Xml file not found, reading from parameter server");
       ros::NodeHandle top_level_node;
-      if (top_level_node.getParam(robot_xml_file.c_str(), g_robot_desc))
-        xml.Parse(g_robot_desc.c_str());
+      if (top_level_node.getParam(robot_xml_file_.c_str(), g_robot_desc_))
+        xml.Parse(g_robot_desc_.c_str());
       else
       {
-        ROS_FATAL("Could not load the xml from parameter server: %s", robot_xml_file.c_str());
+        ROS_FATAL("Could not load the xml from parameter server: %s", robot_xml_file_.c_str());
         throw "end";
       }
     }
@@ -314,12 +314,12 @@ namespace OpenControllersInterface {
     root = xml.FirstChildElement("robot");
     if (!root || !root_element)
     {
-      ROS_FATAL("Could not parse the xml from %s", robot_xml_file.c_str());
+      ROS_FATAL("Could not parse the xml from %s", robot_xml_file_.c_str());
       throw "end";
     }
 
     // Initialize the controller manager from robot description
-    if (!cm->initXml(root))
+    if (!cm_->initXml(root))
     {
       ROS_FATAL("Could not initialize the controller manager");
       throw "end";
@@ -347,14 +347,14 @@ namespace OpenControllersInterface {
   double OpenController::publishJitter(double start) 
   {
     double jitter = now() - start;
-    g_stats.jitter_acc(jitter);
+    g_stats_.jitter_acc(jitter);
     // Publish realtime loops statistics, if requested
-    if (rtpublisher)
+    if (rtpublisher_)
       {
-        if (rtpublisher->trylock())
+        if (rtpublisher_->trylock())
           {
-            rtpublisher->msg_.data  = jitter;
-            rtpublisher->unlockAndPublish();
+            rtpublisher_->msg_.data  = jitter;
+            rtpublisher_->unlockAndPublish();
           }
       }
     return jitter;
@@ -374,38 +374,38 @@ namespace OpenControllersInterface {
 
     // Keep history of last 3 calculation intervals.
     // the value is Hz we supporsed for realtime loop to be in
-    RTLoopHistory rt_loop_history(3, 1.0 / (period / NSEC_PER_SECOND)); 
-    double rt_loop_monitor_period = 0.6 / 3;
+    RTLoopHistory rt_loop_history(3, 1.0 / (period_ / NSEC_PER_SECOND)); 
+    double rt_loop_monitor_period_ = 0.6 / 3;
     unsigned long rt_cycle_count = 0;
     struct timespec tick;
     clock_gettime(CLOCK_REALTIME, &tick);
     // Snap to the nearest second
-    timespecInc(tick, period);
+    timespecInc(tick, period_);
     clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &tick, NULL);
     double last_published = now();
     double last_loop_start = now();
     double last_rt_monitor_time = now();
     struct timespec last_exec_time;
     clock_gettime(CLOCK_REALTIME, &last_exec_time);
-    g_stats.loop_count = 0;
-    while (!g_quit) {
-      g_stats.loop_count++;
+    g_stats_.loop_count = 0;
+    while (!g_quit_) {
+      g_stats_.loop_count++;
       // Track how long the actual loop takes
       double this_loop_start = now();
-      g_stats.loop_acc(this_loop_start - last_loop_start);
+      g_stats_.loop_acc(this_loop_start - last_loop_start);
       last_loop_start = this_loop_start;
       bool success_update_joint = false;
       double start = now();
-      if (g_reset_motors) {
-        //ec.update(true, g_halt_motors);
-        g_reset_motors = false;
+      if (g_reset_motors_) {
+        //ec.update(true, g_halt_motors_);
+        g_reset_motors_ = false;
         // Also, clear error flags when motor reset is requested
-        g_stats.rt_loop_not_making_timing = false;
+        g_stats_.rt_loop_not_making_timing = false;
       }
       else {
         // struct timespec current_time;
         // clock_gettime(CLOCK_REALTIME, &current_time);
-        // timespecInc(exec_time, period);
+        // timespecInc(exec_time, period_);
         // if (((exec_time.tv_sec - current_time.tv_sec) + double(exec_time.tv_nsec - current_time.tv_nsec) / NSEC_PER_SECOND) > 0) {
         //   ROS_INFO("sleep %f", ((exec_time.tv_sec - current_time.tv_sec) + double(exec_time.tv_nsec - current_time.tv_nsec) / NSEC_PER_SECOND));
         //   clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &exec_time, NULL);
@@ -421,22 +421,22 @@ namespace OpenControllersInterface {
         last_exec_time.tv_nsec = exec_time.tv_nsec;
       }
 
-      if (g_publish_trace_requested)
+      if (g_publish_trace_requested_)
       {
-        g_publish_trace_requested = false;
+        g_publish_trace_requested_ = false;
 #if 0
         ec.publishTrace(-1,"",0,0);
 #endif
       }
-      g_halt_motors = false;
+      g_halt_motors_ = false;
       double after_ec = now();
       if (success_update_joint) {
-        cm->update();
+        cm_->update();
       }
       double end = now();
 
-      g_stats.ec_acc(after_ec - start);
-      g_stats.cm_acc(end - after_ec);
+      g_stats_.ec_acc(after_ec - start);
+      g_stats_.cm_acc(end - after_ec);
 
       if ((end - last_published) > 1.0)
       {
@@ -449,30 +449,30 @@ namespace OpenControllersInterface {
       // When realtime loop misses a lot of cycles controllers will perform poorly and may cause robot to shake.
       // Halt motors if realtime loop does not run enough cycles over a given period.
       ++rt_cycle_count;
-      if ((start - last_rt_monitor_time) > rt_loop_monitor_period)
+      if ((start - last_rt_monitor_time) > rt_loop_monitor_period_)
       {
         // Calculate new average rt loop frequency       
-        double rt_loop_frequency = double(rt_cycle_count) / rt_loop_monitor_period;
+        double rt_loop_frequency = double(rt_cycle_count) / rt_loop_monitor_period_;
 
         // Use last X samples of frequency when deciding whether or not to halt
         rt_loop_history.sample(rt_loop_frequency);
         double avg_rt_loop_frequency = rt_loop_history.average();
-        if (avg_rt_loop_frequency < min_acceptable_rt_loop_frequency)
+        if (avg_rt_loop_frequency < min_acceptable_rt_loop_frequency_)
         {
-          g_halt_motors = true;
-          if (!g_stats.rt_loop_not_making_timing)
+          g_halt_motors_ = true;
+          if (!g_stats_.rt_loop_not_making_timing)
           {
             // Only update this value if motors when this first occurs (used for diagnostics error message)
-            g_stats.halt_rt_loop_frequency = avg_rt_loop_frequency;
+            g_stats_.halt_rt_loop_frequency = avg_rt_loop_frequency;
           }
-          g_stats.rt_loop_not_making_timing = true;
+          g_stats_.rt_loop_not_making_timing = true;
         }
-        g_stats.rt_loop_frequency = avg_rt_loop_frequency;
+        g_stats_.rt_loop_frequency = avg_rt_loop_frequency;
         rt_cycle_count = 0;
         last_rt_monitor_time = start;
       }
       // Compute end of next period
-      timespecInc(tick, period);
+      timespecInc(tick, period_);
 
       struct timespec before; 
       clock_gettime(CLOCK_REALTIME, &before); 
@@ -483,38 +483,38 @@ namespace OpenControllersInterface {
         ROS_WARN("overrun: %f", overrun_time);
         double jitter = publishJitter(start);
         ROS_WARN("jitter: %f", jitter);
-        ROS_WARN("loop:   %d", g_stats.loop_count);
+        ROS_WARN("loop:   %d", g_stats_.loop_count);
         // Total amount of time the loop took to run
-        g_stats.overrun_loop_sec = overrun_time;
+        g_stats_.overrun_loop_sec = overrun_time;
 
         // We overran, snap to next "period"
         // ueda
-        //timespecInc(tick, (before.tv_nsec / period + 1) * period);
+        //timespecInc(tick, (before.tv_nsec / period_ + 1) * period_);
         tick.tv_sec = before.tv_sec;
-        // tick.tv_nsec = (before.tv_nsec / period) * period;
+        // tick.tv_nsec = (before.tv_nsec / period_) * period_;
         tick.tv_nsec = before.tv_nsec;
-        timespecInc(tick, period);
+        timespecInc(tick, period_);
 
         // initialize overruns
-        if (g_stats.overruns == 0){
-          g_stats.last_overrun = 1000;
-          g_stats.last_severe_overrun = 1000;
+        if (g_stats_.overruns == 0){
+          g_stats_.last_overrun = 1000;
+          g_stats_.last_severe_overrun = 1000;
         }
         // check for overruns
-        if (g_stats.recent_overruns > 10)
-          g_stats.last_severe_overrun = 0;
-        g_stats.last_overrun = 0;
+        if (g_stats_.recent_overruns > 10)
+          g_stats_.last_severe_overrun = 0;
+        g_stats_.last_overrun = 0;
 
-        g_stats.overruns++;
-        g_stats.recent_overruns++;
-        g_stats.overrun_ec = after_ec - start;
-        g_stats.overrun_cm = end - after_ec;
+        g_stats_.overruns++;
+        g_stats_.recent_overruns++;
+        g_stats_.overrun_ec = after_ec - start;
+        g_stats_.overrun_cm = end - after_ec;
       }
 
       struct timespec sleep_before;
       clock_gettime(CLOCK_REALTIME, &sleep_before);
       // Sleep until end of period
-      if (!not_sleep_clock)
+      if (!not_sleep_clock_)
         clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &tick, NULL);
       if (overrun_time <= 0.0)
         publishJitter(start);
@@ -529,12 +529,12 @@ namespace OpenControllersInterface {
       }
 
       // Halt the motors, if requested by a service call
-      if (g_halt_requested)
+      if (g_halt_requested_)
       {
         fprintf(stderr, "detect halt request\n");
-        g_quit = true;
-        g_halt_motors = true;
-        g_halt_requested = false;
+        g_quit_ = true;
+        g_halt_motors_ = true;
+        g_halt_requested_ = false;
       }
       //ROS_INFO("end of loop");
     }
@@ -545,7 +545,7 @@ namespace OpenControllersInterface {
     ROS_WARN("finalizing");
     finalizeHW();
     /* Shutdown all of the motors on exit */
-    for (pr2_hardware_interface::ActuatorMap::const_iterator it = hw->actuators_.begin(); it != hw->actuators_.end(); ++it)
+    for (pr2_hardware_interface::ActuatorMap::const_iterator it = hw_->actuators_.begin(); it != hw_->actuators_.end(); ++it)
     {
       it->second->command_.enable_ = false;
       it->second->command_.effort_ = 0;
@@ -554,11 +554,11 @@ namespace OpenControllersInterface {
     ec.update(false, true);
 #endif
     //pthread_join(diagnosticThread, 0);
-    if (publisher) {
-      publisher->stop();
-      publisher = NULL;
+    if (publisher_) {
+      publisher_->stop();
+      publisher_ = NULL;
     }
-    delete rtpublisher;
+    delete rtpublisher_;
     //ros::shutdown();
     //return (void *)rv;
     fprintf(stderr, "exiting from finalize\n");
@@ -568,7 +568,7 @@ namespace OpenControllersInterface {
     //EthercatHardware *ec((EthercatHardware *) args);
     struct timespec tick;
     clock_gettime(CLOCK_MONOTONIC, &tick);
-    while (!g_quit) {
+    while (!g_quit_) {
       //ec->collectDiagnostics();
       tick.tv_sec += 1;
       clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &tick, NULL);
@@ -593,9 +593,9 @@ namespace OpenControllersInterface {
     pid_t pid;
     int fd;
     FILE *fp = NULL;
-    boost::filesystem::path fullpath = boost::filesystem::path(piddir) / boost::filesystem::path(pidfile);
+    boost::filesystem::path fullpath = boost::filesystem::path(piddir_) / boost::filesystem::path(pidfile_);
     umask(0);
-    mkdir(piddir.c_str(), 0777);
+    mkdir(piddir_.c_str(), 0777);
     fd = open(fullpath.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
     if (fd == -1)
     {
@@ -664,7 +664,7 @@ namespace OpenControllersInterface {
   }
 
   void OpenController::cleanupPidFile() {
-    boost::filesystem::path path = boost::filesystem::path(piddir) / boost::filesystem::path(pidfile);
+    boost::filesystem::path path = boost::filesystem::path(piddir_) / boost::filesystem::path(pidfile_);
     unlink(path.c_str());
   }
   
@@ -682,7 +682,7 @@ namespace OpenControllersInterface {
   }
 
   void OpenController::quitRequest() {
-    g_halt_requested = true;
+    g_halt_requested_ = true;
   }
 
   bool OpenController::initRT() {

--- a/open_controllers_interface/src/open_controllers_interface.cpp
+++ b/open_controllers_interface/src/open_controllers_interface.cpp
@@ -93,8 +93,10 @@ namespace OpenControllersInterface {
         ControllerStatusPtr st = recoverController();
         if (!st || !st->isHealthy())
         {
+          ROS_FATAL("oh no, no way to recover! quit!");
           g_quit_ = true;
         }
+        g_reset_motors_ = false;
       }
     }
     ROS_INFO("good bye start()");

--- a/open_controllers_interface/src/open_controllers_interface.cpp
+++ b/open_controllers_interface/src/open_controllers_interface.cpp
@@ -397,7 +397,6 @@ namespace OpenControllersInterface {
       bool success_update_joint = false;
       double start = now();
       if (g_reset_motors_) {
-        //ec.update(true, g_halt_motors_);
         g_reset_motors_ = false;
         // Also, clear error flags when motor reset is requested
         g_stats_.rt_loop_not_making_timing = false;
@@ -428,7 +427,6 @@ namespace OpenControllersInterface {
         ec.publishTrace(-1,"",0,0);
 #endif
       }
-      g_halt_motors_ = false;
       double after_ec = now();
       if (success_update_joint) {
         cm_->update();
@@ -459,7 +457,6 @@ namespace OpenControllersInterface {
         double avg_rt_loop_frequency = rt_loop_history.average();
         if (avg_rt_loop_frequency < min_acceptable_rt_loop_frequency_)
         {
-          g_halt_motors_ = true;
           if (!g_stats_.rt_loop_not_making_timing)
           {
             // Only update this value if motors when this first occurs (used for diagnostics error message)
@@ -533,7 +530,6 @@ namespace OpenControllersInterface {
       {
         fprintf(stderr, "detect halt request\n");
         g_quit_ = true;
-        g_halt_motors_ = true;
         g_halt_requested_ = false;
       }
       //ROS_INFO("end of loop");


### PR DESCRIPTION
- indent warning output
- minor fix
- add a boilerplait for recovering controller
- g_halt_motors_ is not used
- do not use raw pointer
- follow standard c++ style class member naming
- add initializeCM virtual function for pre/post-processing by successor
